### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nbility-model.github.io
 
-This repository hosts the source code for the Nbility-model documentation website at <https://nbility-model.github.io>.
+This repository hosts the source code for the Nbility-model documentation website at <[https://nbility-model.github.io](https://nbility.netbeheernederland.nl/)>.
 
 ## Testing/previewing the documentation site locally
 


### PR DESCRIPTION
This PR fixes a broken link in the README by updating it to point to the correct documentation website.

Specifically, it corrects the link in:
https://github.com/NBility-Model/nbility-model.github.io/blob/main/README.md